### PR TITLE
Remove roave/security-advisories 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "phpcompatibility/php-compatibility": "^9.3",
     "phpunit/php-code-coverage": "^9",
     "phpunit/phpunit": "^9",
-    "roave/security-advisories": "dev-latest",
     "roots/wordpress": "^6.7",
     "squizlabs/php_codesniffer": "^3.2",
     "symfony/var-dumper": "^6.4 || ^7.2",


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132